### PR TITLE
Add MariaDB support to ADE.

### DIFF
--- a/ade-core/src/main/java/org/openmainframe/ade/dbUtils/ConnectionWrapper.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/dbUtils/ConnectionWrapper.java
@@ -185,16 +185,19 @@ public class ConnectionWrapper {
      */
     public void endTransaction() throws SQLException {
         if (m_returnAutoCommit) {
-            unlockTables();
             m_connection.setAutoCommit(true);
 
             m_returnAutoCommit = false;
         }
+        unlockTables();
     }
 
     private void unlockTables() throws SQLException {
         switch (s_driverType.get()) {
             case MY_SQL:
+                executeDml("unlock tables");
+                break;
+            case MARIADB:
                 executeDml("unlock tables");
                 break;
             default:
@@ -251,6 +254,9 @@ public class ConnectionWrapper {
             case MY_SQL:
                 executeDml("lock table " + tableName + " write");
                 break;
+            case MARIADB:
+                executeDml("lock table " + tableName + " write");
+                break;
             default:
                 executeDml("lock table " + tableName + " in exclusive mode");
         }
@@ -259,6 +265,9 @@ public class ConnectionWrapper {
     public void lockTableShare(String tableName) throws SQLException {
         switch (s_driverType.get()) {
             case MY_SQL:
+                executeDml("lock table " + tableName + " read");
+                break;
+            case MARIADB:
                 executeDml("lock table " + tableName + " read");
                 break;
             default:

--- a/ade-core/src/main/java/org/openmainframe/ade/dbUtils/DriverType.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/dbUtils/DriverType.java
@@ -20,7 +20,7 @@
 package org.openmainframe.ade.dbUtils;
 
 public enum DriverType {
-    DB2("db2"), DERBY("derby"), MY_SQL("mysql");
+    DB2("db2"), DERBY("derby"), MY_SQL("mysql"), MARIADB("mariadb");
 
     public static DriverType parseDriverType(String driver) {
         driver = driver.toLowerCase();

--- a/ade-core/src/main/java/org/openmainframe/ade/dbUtils/SimpleQueries.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/dbUtils/SimpleQueries.java
@@ -49,7 +49,8 @@ public class SimpleQueries {
      * @throws AdeException
      */
     public final int getLastKey() throws AdeException {
-        if (Ade.getAde().getConfigProperties().database().getDatabaseDriver().contains("mysql")) {
+        if ((Ade.getAde().getConfigProperties().database().getDatabaseDriver().contains("mysql")) ||
+            (Ade.getAde().getConfigProperties().database().getDatabaseDriver().contains("mariadb"))) {
             return executeIntQuery("SELECT LAST_INSERT_ID()", true);
         }
         return executeIntQuery("values IDENTITY_VAL_LOCAL()", true);

--- a/ade-core/src/main/java/org/openmainframe/ade/impl/dataStore/SQL.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/impl/dataStore/SQL.java
@@ -213,8 +213,10 @@ public enum SQL {
 
         final String driver = Ade.getAde().getConfigProperties().database().getDatabaseDriver();
 
-        if (DriverType.parseDriverType(driver) == DriverType.MY_SQL) {
+        if ((DriverType.parseDriverType(driver) == DriverType.MY_SQL) ||
+            (DriverType.parseDriverType(driver) == DriverType.MARIADB)) {
             createString = createString.replace("GENERATED ALWAYS AS IDENTITY NOT NULL", "NOT NULL AUTO_INCREMENT");
+            createString = createString.replace("GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1)", "AUTO_INCREMENT");
         }
         return createString;
     }

--- a/ade-core/src/main/java/org/openmainframe/ade/impl/dataStore/TableManager.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/impl/dataStore/TableManager.java
@@ -149,7 +149,8 @@ public class TableManager {
         final String driver = Ade.getAde().getConfigProperties().database().getDatabaseDriver();
 
         String query = "insert into " + SQL.ADE_VERSIONS + " (ADE_VERSION, PATCHED_TIME) values ('" + Ade.getAde().getDbVersion() + "', current timestamp)";
-        if (DriverType.parseDriverType(driver) == DriverType.MY_SQL) {
+        if ((DriverType.parseDriverType(driver) == DriverType.MY_SQL) ||
+            (DriverType.parseDriverType(driver) == DriverType.MARIADB)) {
             query = query.replace("current timestamp", "current_timestamp");
         }
 

--- a/ade-core/src/main/java/org/openmainframe/ade/impl/dbUtils/DmlPreparedStatementChunkExecuter.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/impl/dbUtils/DmlPreparedStatementChunkExecuter.java
@@ -64,7 +64,8 @@ public abstract class DmlPreparedStatementChunkExecuter extends DmlStatementExec
     protected void createAndExecute(String sqlString) throws SQLException, AdeException {
         m_stmt = m_preparedStatement = m_con.prepareStatement(sqlString);
         setAllParameters(m_preparedStatement);
-        flush();
+        if (m_stmtCount > 0)
+            flush();
     }
 
     protected abstract void setAllParameters(PreparedStatement stmt) throws SQLException, AdeException;

--- a/ade-core/src/main/java/org/openmainframe/ade/impl/dbUtils/SpecialSqlQueries.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/impl/dbUtils/SpecialSqlQueries.java
@@ -45,7 +45,8 @@ public final class SpecialSqlQueries {
      * @throws AdeException
      */
     public static int getLastKey() throws AdeException {
-        if (Ade.getAde().getConfigProperties().database().getDatabaseDriver().contains("mysql")) {
+        if ((Ade.getAde().getConfigProperties().database().getDatabaseDriver().contains("mysql")) ||
+	    (Ade.getAde().getConfigProperties().database().getDatabaseDriver().contains("mariadb"))) {
             return executeIntQuery("SELECT LAST_INSERT_ID()");
         }
         return executeIntQuery("values IDENTITY_VAL_LOCAL()");

--- a/ade-core/src/main/java/org/openmainframe/ade/impl/dbUtils/TableGeneralUtils.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/impl/dbUtils/TableGeneralUtils.java
@@ -137,8 +137,9 @@ public final class TableGeneralUtils {
         final ConnectionWrapper cw = new ConnectionWrapper(AdeInternal.getDefaultConnection());
         final String tableName = table.toString();
         try {
-            if (Ade.getAde().getConfigProperties().database().getDatabaseDriver().contains("mysql")) {
-                cw.executeDml("lock table " + tableName + " write");
+            if ((Ade.getAde().getConfigProperties().database().getDatabaseDriver().contains("mysql")) || 
+                (Ade.getAde().getConfigProperties().database().getDatabaseDriver().contains("mariadb"))) {
+                cw.executeDml("lock tables " + tableName + " write");
                 cw.close();
             } else {
                 cw.executeDml("lock table " + tableName + " in exclusive mode");
@@ -153,8 +154,9 @@ public final class TableGeneralUtils {
         final String tableName = table.toString();
         final ConnectionWrapper cw = new ConnectionWrapper(AdeInternal.getDefaultConnection());
         try {
-            if (Ade.getAde().getConfigProperties().database().getDatabaseDriver().contains("mysql")) {
-                cw.executeDml("lock table " + tableName + " read");
+            if ((Ade.getAde().getConfigProperties().database().getDatabaseDriver().contains("mysql")) ||
+                (Ade.getAde().getConfigProperties().database().getDatabaseDriver().contains("mariadb"))) {
+                cw.executeDml("lock tables " + tableName + " read");
                 cw.close();
 
             } else {
@@ -188,12 +190,12 @@ public final class TableGeneralUtils {
     }
 
     private static void unlockTables() throws AdeException {
-        if (!Ade.getAde().getConfigProperties().database().getDatabaseDriver().contains("mysql")) {
+        if ((!Ade.getAde().getConfigProperties().database().getDatabaseDriver().contains("mysql")) ||
+            (!Ade.getAde().getConfigProperties().database().getDatabaseDriver().contains("mariadb"))) {
             return;
         }
         final ConnectionWrapper cw = new ConnectionWrapper(AdeInternal.getDefaultConnection());
         try {
-
             cw.executeDml("unlock tables");
             cw.close();
         } catch (SQLException e) {

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/data/ManagedSystemInfo.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/data/ManagedSystemInfo.java
@@ -26,6 +26,8 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.openmainframe.ade.data.ISource;
+import org.openmainframe.ade.Ade;
+import org.openmainframe.ade.dbUtils.DriverType;
 import org.openmainframe.ade.exceptions.AdeException;
 import org.openmainframe.ade.exceptions.AdeInternalException;
 import org.openmainframe.ade.ext.utils.AtomicTransaction;
@@ -143,10 +145,18 @@ public class ManagedSystemInfo {
 
     private class UpdateManagedSystemAtomicTransaction extends AtomicTransaction {
         private ISource source;
+        private boolean mySQL;
 
-        public UpdateManagedSystemAtomicTransaction(ISource source) {
+        public UpdateManagedSystemAtomicTransaction(ISource source) throws AdeException {
             super();
             this.source = source;
+            final String driver = Ade.getAde().getConfigProperties().database().getDatabaseDriver();
+
+            if ((DriverType.parseDriverType(driver) == DriverType.MY_SQL) ||
+                (DriverType.parseDriverType(driver) == DriverType.MARIADB))
+                mySQL = true;
+            else
+                mySQL = false;
         }
 
         public boolean execute() throws AdeException {
@@ -158,7 +168,11 @@ public class ManagedSystemInfo {
         @Override
         public boolean performAtomicTransaction() throws AdeException {
             try {
-                execute("LOCK TABLE " + GroupsQueryImpl.MANAGED_SYSTEMS_TABLE + " IN EXCLUSIVE MODE");
+		if (mySQL) 
+;
+//                    execute("LOCK TABLES " + GroupsQueryImpl.MANAGED_SYSTEMS_TABLE + " WRITE");
+		else
+                    execute("LOCK TABLE " + GroupsQueryImpl.MANAGED_SYSTEMS_TABLE + " IN EXCLUSIVE MODE");
 
                 m_dbqueryManagedSystem = lookupManagedSystemInfo(source);
                 if (m_dbqueryManagedSystem == null) {
@@ -169,6 +183,13 @@ public class ManagedSystemInfo {
             } catch (SQLException e) {
                 logger.error("Error encountered executing the transaction.", e);
             }
+//            if (mySQL) {
+//                try {
+//                    execute("UNLOCK TABLES");
+//                } catch (SQLException e) {
+//                    logger.error("Error encountered unlocking the table.", e);
+//                }
+//            }
 
             return true;
         }

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/data/ManagedSystemInfo.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/data/ManagedSystemInfo.java
@@ -169,8 +169,7 @@ public class ManagedSystemInfo {
         public boolean performAtomicTransaction() throws AdeException {
             try {
 		if (mySQL) 
-;
-//                    execute("LOCK TABLES " + GroupsQueryImpl.MANAGED_SYSTEMS_TABLE + " WRITE");
+                    execute("LOCK TABLES " + GroupsQueryImpl.MANAGED_SYSTEMS_TABLE + " WRITE");
 		else
                     execute("LOCK TABLE " + GroupsQueryImpl.MANAGED_SYSTEMS_TABLE + " IN EXCLUSIVE MODE");
 
@@ -183,13 +182,13 @@ public class ManagedSystemInfo {
             } catch (SQLException e) {
                 logger.error("Error encountered executing the transaction.", e);
             }
-//            if (mySQL) {
-//                try {
-//                    execute("UNLOCK TABLES");
-//                } catch (SQLException e) {
-//                    logger.error("Error encountered unlocking the table.", e);
-//                }
-//            }
+            if (mySQL) {
+                try {
+                    execute("UNLOCK TABLES");
+                } catch (SQLException e) {
+                    logger.error("Error encountered unlocking the table.", e);
+                }
+            }
 
             return true;
         }

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/utils/EXT_TABLES_SQL.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/utils/EXT_TABLES_SQL.java
@@ -19,6 +19,12 @@
 */
 package org.openmainframe.ade.ext.utils;
 
+import org.openmainframe.ade.Ade;
+import org.openmainframe.ade.dbUtils.DriverType;
+import org.openmainframe.ade.exceptions.AdeException;
+import org.openmainframe.ade.summary.SummarizationProperties;
+import org.openmainframe.ade.utils.patches.Version;
+
 /** Create sql statements of ext-specific tables */
 public enum EXT_TABLES_SQL {
 
@@ -55,8 +61,15 @@ public enum EXT_TABLES_SQL {
         this.m_create = create;
     }
 
-    public String create() {
-        return m_create;
-    }
+    public String create() throws AdeException {
+        String createString = m_create;
 
+        final String driver = Ade.getAde().getConfigProperties().database().getDatabaseDriver();
+
+        if ((DriverType.parseDriverType(driver) == DriverType.MY_SQL) ||
+            (DriverType.parseDriverType(driver) == DriverType.MARIADB)) {
+            createString = createString.replace("GENERATED ALWAYS AS IDENTITY NOT NULL", "NOT NULL AUTO_INCREMENT");
+        }
+        return createString;
+    }
 }


### PR DESCRIPTION
There are several changes required to support MariaDB:

1. Unlike the rest of the namespace where mysql is synonymous with MariaDB the driver name for MariaDB is different
2. An additional statement needs changing at run time to support the MariaDB syntax
3. An unlock is still required at end transaction time regardless of autocommit setting
4. MariaDB has different locking requirements so much of the work is related to implementing this. If you lock a table and then try and access another table which is not locked MariaDB will complain:

```
2016-03-01 05:20:13,971 [main] INFO  (ExtControlProgram.java:138) - Starting execution: UPLOAD
2016-03-01 05:20:17,151 [main] WARN  (RuntimeModelDataManager.java:318) - Reading RuntimeModelData: Runtime model data file does not exist.  Nothing to load: /var/local/ade/output/continuous/docker/runtimeModelData.ser
org.openmainframe.ade.exceptions.AdeInternalException: Database access error
at org.openmainframe.ade.dbUtils.ConnectionWrapper.failed(ConnectionWrapper.java:132)
at org.openmainframe.ade.impl.dataStore.DataStoreGroupsImpl.getUnassignedGroupInternalId(DataStoreGroupsImpl.java:145)
:
Caused by: org.mariadb.jdbc.internal.util.dao.QueryException: Table 'GROUPS' was not locked with LOCK TABLES
at org.mariadb.jdbc.internal.protocol.AbstractQueryProtocol.getResult(AbstractQueryProtocol.java:479)
:
```

In addition, a batch insert should only be flushed if there is data to be flushed.