### PR TITLE
Code quality fix - Useless parentheses around expressions should be removed to prevent any misunderstanding.

### DIFF
--- a/ade-core/src/main/java/org/openmainframe/ade/core/clustering/IClustExp.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/core/clustering/IClustExp.java
@@ -292,7 +292,7 @@ public class IClustExp implements IClusteringAlgorithm {
                 if (totalN > 0) {
                     newScore = (mSize - 1) * (mSimilaritySum - mCandidateExtraSum) / totalN;
                 }
-                return (scoreContribution() - newScore);
+                return scoreContribution() - newScore;
             }
 
             private double candidateContribution() {
@@ -303,7 +303,7 @@ public class IClustExp implements IClusteringAlgorithm {
                 if (totalN > 0) {
                     newScore = (mSize + 1) * (mCandidateExtraSum + mSimilaritySum) / totalN;
                 }
-                return (newScore - scoreContribution());
+                return newScore - scoreContribution();
 
             }
 
@@ -587,7 +587,7 @@ public class IClustExp implements IClusteringAlgorithm {
                         partition.mSeed, mIdleTrials));
             }
             if (bestPartition == null || partition.mTotalScore > bestPartition.mTotalScore) {
-                mConverged = (mTrials < mMaxTrialNum);
+                mConverged = mTrials < mMaxTrialNum;
                 bestPartition = partition;
             }
             if (partition.getScore() >= 1) {

--- a/ade-core/src/main/java/org/openmainframe/ade/impl/dataStore/DataStorePeriodsImpl.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/impl/dataStore/DataStorePeriodsImpl.java
@@ -271,7 +271,7 @@ public class DataStorePeriodsImpl implements IDataStorePeriods {
             int pos = 1;
             final int periodInternalId = rs.getInt(pos++);
             final int temp = rs.getInt(pos++);
-            boolean excludeFromTraining = (temp > 0);
+            boolean excludeFromTraining = temp > 0;
             final int status = rs.getInt(pos++);
             final String comment = rs.getString(pos++);
             
@@ -342,7 +342,7 @@ public class DataStorePeriodsImpl implements IDataStorePeriods {
             int pos = 1;
             final int periodInternalId = rs.getInt(pos++);
             final int temp = rs.getInt(pos++);
-            boolean excludeFromTraining = (temp > 0);
+            boolean excludeFromTraining = temp > 0;
             final int status = rs.getInt(pos++);
             final String comment = rs.getString(pos++);
             final Date startTime = PreparedStatementWrapper.getResultSetTimestamp(rs, pos++);

--- a/ade-core/src/main/java/org/openmainframe/ade/scores/AdeAnomalyIntervalScorer.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/scores/AdeAnomalyIntervalScorer.java
@@ -191,7 +191,7 @@ public class AdeAnomalyIntervalScorer extends IntervalAnomalyScorer {
         Collections.sort(m_rawScores);
         final int numIntervals = m_rawScores.size();
         for (int i = 0; i < NUM_BUCKETS; i++) {
-            final int index = ((numIntervals * i) / NUM_BUCKETS);
+            final int index = (numIntervals * i) / NUM_BUCKETS;
             m_percentiles[i] = m_rawScores.get(index);
         }
 

--- a/ade-core/src/main/java/org/openmainframe/ade/scores/LogNormalScore.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/scores/LogNormalScore.java
@@ -236,7 +236,7 @@ public class LogNormalScore extends MessageScorer {
     private boolean locateMismatchingDistributions(MsgData data) throws AdeException {
 
         final double maxScore = -calcLogProb(data.m_maxNumAppearance, data.m_lambda);
-        return (maxScore >= m_badMessageCountScoreThreshold);
+        return maxScore >= m_badMessageCountScoreThreshold;
     }
 
     /**
@@ -342,7 +342,7 @@ public class LogNormalScore extends MessageScorer {
 
         final double sigma = calcSigmaFromMu(mu);
 
-        return (-s_logSqrtTwoPi - Math.log(sigma));
+        return -s_logSqrtTwoPi - Math.log(sigma);
     }
 
     /**

--- a/ade-core/src/main/java/org/openmainframe/ade/scores/MaxInformation1ContextScore.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/scores/MaxInformation1ContextScore.java
@@ -266,7 +266,7 @@ public class MaxInformation1ContextScore extends MessageScorer {
 
     @Override
     public boolean needsAnotherIteration() throws AdeException {
-        return (!m_doneTrain);
+        return !m_doneTrain;
     }
 
     @Override

--- a/ade-core/src/main/java/org/openmainframe/ade/scores/PercentileScorer.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/scores/PercentileScorer.java
@@ -188,7 +188,7 @@ public class PercentileScorer implements IScorer<Double, Double> {
         final double step = ((double) m_totalNumObservations + 1.0) / (NUM_PERCENTILE_BINS);
         for (int i = 0; i < NUM_PERCENTILE_BINS; ++i) {
             double tmp_score = 0.0;
-            final double exactIndex = (step * i);
+            final double exactIndex = step * i;
             final int index = (int) Math.floor(exactIndex);
             if (index == 0) { //  -> 7.2.5.2 case 2 
 

--- a/ade-core/src/main/java/org/openmainframe/ade/utils/LockedInputStream.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/utils/LockedInputStream.java
@@ -83,7 +83,7 @@ public class LockedInputStream extends InputStream {
 
     @Override
     public int read() throws IOException {
-        return (m_raf.read());
+        return m_raf.read();
     }
 
 }

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/data/Group.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/data/Group.java
@@ -137,7 +137,7 @@ public class Group {
         if (o == this) return true;
         if (!(o instanceof Group)) return false;
         Group group = (Group) o;
-        return  (group.name.equalsIgnoreCase(name) && (group.groupType == groupType));
+        return  group.name.equalsIgnoreCase(name) && (group.groupType == groupType);
     }
 
     @Override

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/data/GroupsQueryImpl.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/data/GroupsQueryImpl.java
@@ -189,7 +189,7 @@ public final class GroupsQueryImpl {
             short evaluationOrder = resultSet.getShort("EVALUATION_ORDER");
             int rid = resultSet.getInt("RULE_INTERNAL_ID");
             String ruleName = getRuleName(rid);
-            return (new Group(uid,name,groupType,dataType,evaluationOrder,ruleName));            
+            return new Group(uid,name,groupType,dataType,evaluationOrder,ruleName);            
         }
         /**
          * Retrieves the rule name by selecting the row with the given unique rule id. 

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/data/Rule.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/data/Rule.java
@@ -105,7 +105,7 @@ public class Rule {
         if (o == this) return true;
         if (!(o instanceof Rule)) return false;
         Rule rule = (Rule) o;
-        return  (rule.name.equalsIgnoreCase(name));
+        return  rule.name.equalsIgnoreCase(name);
     }
 
     @Override

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/data/RulesQueryImpl.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/data/RulesQueryImpl.java
@@ -101,7 +101,7 @@ public final class RulesQueryImpl {
             String description = ruleListResultSet.getString("DESCRIPTION");
             String rule = ruleListResultSet.getString("RULE");
             
-            return (new Rule(uid, name, rule, description));
+            return new Rule(uid, name, rule, description);
         }    
     }
 

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/main/helper/AdeInputStreamHandlerExt.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/main/helper/AdeInputStreamHandlerExt.java
@@ -130,6 +130,6 @@ public class AdeInputStreamHandlerExt extends AdeInputStreamHandler {
      */
     protected final String getNameForStdin() {
         final SimpleDateFormat F = new SimpleDateFormat("-hhmmss-MMddyyyy");
-        return ("stdin" + F.format(new Date()));
+        return "stdin" + F.format(new Date());
     }
 }

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/main/helper/UploadOrAnalyze.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/main/helper/UploadOrAnalyze.java
@@ -63,7 +63,7 @@ abstract public class UploadOrAnalyze extends ExtControlProgram {
             return false;
         }
 
-        return (s_uploadOrAnalyzeObject.getInputSource() == INPUT_SOURCE.STDIN);
+        return s_uploadOrAnalyzeObject.getInputSource() == INPUT_SOURCE.STDIN;
     }
 
     public static AdeExtRequestType getAdeRequestType() {

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/os/LinuxAdeExtProperties.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/os/LinuxAdeExtProperties.java
@@ -63,7 +63,7 @@ public class LinuxAdeExtProperties extends AdeExtProperties {
      * @param year
      */
     public boolean isYearDefined() {
-        return (year != YEAR_NOT_DEFINED);
+        return year != YEAR_NOT_DEFINED;
     }
 
     /**

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/output/XMLUtil.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/output/XMLUtil.java
@@ -52,7 +52,7 @@ public final class XMLUtil {
      */
     public static int getNumberOfSnapshots(FramingFlowType fft) {
         long minutesInDay = DateTimeUtils.HOURS_IN_DAY * DateTimeUtils.MINUTES_IN_HOUR;
-        long numMinutesPerSnapShot = (XMLUtil.getXMLHardenedDurationInMillis(fft) / DateTimeUtils.MILLIS_IN_MINUTE);
+        long numMinutesPerSnapShot = XMLUtil.getXMLHardenedDurationInMillis(fft) / DateTimeUtils.MILLIS_IN_MINUTE;
         return (int) (minutesInDay / numMinutesPerSnapShot);
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck

Please let me know if you have any questions.

Faisal Hameed