### PR TITLE
Code quality fix - Redundant casts should not be used.

### DIFF
--- a/ade-core/src/main/java/org/openmainframe/ade/scores/PoissonScore.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/scores/PoissonScore.java
@@ -167,7 +167,7 @@ public class PoissonScore extends MessageScorer {
             numAppear = Math.min(numAppear, MAX_NUM_APPEAR);
         }
         // k *(log lambda) - lambda - (log k!)
-        final double res = (double) (numAppear * Math.log(lambda)) - lambda
+        final double res = (numAppear * Math.log(lambda)) - lambda
                 - m_logFactorials.computeLogFactorial(numAppear);
 
         assert (res <= 0);

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/stats/MessageRateStats.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/stats/MessageRateStats.java
@@ -341,12 +341,12 @@ public class MessageRateStats {
         long prevMessageInputTime = m_messageInputDateTime.getMillis();
         if (prevMessageInputTime % TEN_MINUTES > 0) {
 
-            prevMessageInputTime = TEN_MINUTES * (long) (prevMessageInputTime / TEN_MINUTES) + TEN_MINUTES;
+            prevMessageInputTime = TEN_MINUTES * (prevMessageInputTime / TEN_MINUTES) + TEN_MINUTES;
         }
         final DateTime prevMessageDateTime = new DateTime(prevMessageInputTime).withZone(s_outTimeZone);
 
         /* Find the end of the 10 minutes interval before the next message */
-        nextMessageInputTime = TEN_MINUTES * (long) (nextMessageInputTime / TEN_MINUTES);
+        nextMessageInputTime = TEN_MINUTES * (nextMessageInputTime / TEN_MINUTES);
         final DateTime nextMessageDateTime = new DateTime(nextMessageInputTime).withZone(s_outTimeZone);
 
         /* Find the number of 10 minutes interval being skipped */
@@ -934,7 +934,7 @@ public class MessageRateStats {
          */
         public double getMsg1UniqueMsgIdVariance() {
             final double variance = (double) m_sumOfMsg1UniqueMsgIdCountSquare / (double) m_numberOfIntervals -
-                    -((double) getMsg1UniqueMsgIdMean() * (double) getMsg1UniqueMsgIdMean());
+                    -(getMsg1UniqueMsgIdMean() * getMsg1UniqueMsgIdMean());
             return variance;
         }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1905 - Redundant casts should not be used
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1905

Please let me know if you have any questions.

Faisal Hameed