### PR TITLE
Code quality fix -  "entrySet()" should be iterated when both the key and value are needed.

### DIFF
--- a/ade-core/src/main/java/org/openmainframe/ade/scores/BernoulliScore.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/scores/BernoulliScore.java
@@ -21,6 +21,7 @@ package org.openmainframe.ade.scores;
 
 import java.io.PrintStream;
 import java.io.Serializable;
+import java.util.Map.Entry;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
@@ -143,9 +144,9 @@ public class BernoulliScore extends MessageScorer {
         super.debugPrint(out);
         out.println("Trained=" + m_trained);
         out.println("Total interval count=" + m_totalIntervalCount);
-        for (String key : m_msgData.keySet()) {
-            final MsgData value = m_msgData.get(key);
-            out.println(key + " : " + value);
+        for (Entry<String, MsgData> msg : m_msgData.entrySet()) {
+            final MsgData value = msg.getValue();
+            out.println(msg.getKey() + " : " + value);
         }
     }
 

--- a/ade-core/src/main/java/org/openmainframe/ade/scores/LastSeenScorer.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/scores/LastSeenScorer.java
@@ -156,9 +156,9 @@ public class LastSeenScorer extends MessageScorer {
                         logger.info("trainig last seen model for "
                                 + name);
                     }
-                    for (int i : mPointDifferences.keySet()) {
-                        logger.info("  " + i + ", "
-                                + mPointDifferences.get(i));
+                    for (Entry<Integer, Integer> pointDiff : mPointDifferences.entrySet()) {
+                        logger.info("  " + pointDiff.getKey() + ", "
+                                + pointDiff.getValue());
                     }
                 }
                 computeScores();
@@ -282,9 +282,9 @@ public class LastSeenScorer extends MessageScorer {
                 out.println("Last seen model for " + name + ": " + getLLMax());
             }
             if (m_pointScores != null && !m_pointScores.isEmpty()) {
-                for (int i : m_pointScores.keySet()) {
-                    out.println("  " + i + ", "
-                            + m_pointScores.get(i));
+                for (Entry<Integer, Double> pointScore : m_pointScores.entrySet()) {
+                    out.println("  " + pointScore.getKey() + ", "
+                            + pointScore.getValue());
                 }
                 out.println("  missing, "
                         + -m_logHalf);
@@ -420,9 +420,9 @@ public class LastSeenScorer extends MessageScorer {
      */
     @Override
     public void endOfStream() throws AdeException, AdeFlowException {
-        for (String name : m_lastSeen.keySet()) {
-            final PerodicityBounder pb = m_lastSeen.get(name);
-            pb.train(name);
+        for (Entry<String, PerodicityBounder> last : m_lastSeen.entrySet()) {
+            final PerodicityBounder pb = last.getValue();
+            pb.train(last.getKey());
         }
         m_trained = true;
     }
@@ -433,8 +433,8 @@ public class LastSeenScorer extends MessageScorer {
     @Override
     public void debugPrint(PrintStream out) throws AdeException {
         super.debugPrint(out);
-        for (String name : m_lastSeen.keySet()) {
-            m_lastSeen.get(name).debugPrint(name, out);
+        for (Entry<String, PerodicityBounder> last : m_lastSeen.entrySet()) {
+            last.getValue().debugPrint(last.getKey(), out);
         }
 
     }

--- a/ade-core/src/main/java/org/openmainframe/ade/scores/LogNormalScore.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/scores/LogNormalScore.java
@@ -21,6 +21,7 @@ package org.openmainframe.ade.scores;
 
 import java.io.PrintStream;
 import java.io.Serializable;
+import java.util.Map.Entry;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
@@ -369,9 +370,9 @@ public class LogNormalScore extends MessageScorer {
         out.println("Trained=" + m_trained);
         out.println("Total interval count=" + m_totalIntervalCount);
         out.println("min lambda=" + m_minLambda);
-        for (String key : m_msgData.keySet()) {
-            final MsgData value = m_msgData.get(key);
-            out.println(key + " : " + value);
+        for (Entry<String, MsgData> msg : m_msgData.entrySet()) {
+            final MsgData value = msg.getValue();
+            out.println(msg.getKey() + " : " + value);
         }
     }
 

--- a/ade-core/src/main/java/org/openmainframe/ade/scores/PoissonScore.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/scores/PoissonScore.java
@@ -21,6 +21,7 @@ package org.openmainframe.ade.scores;
 
 import java.io.PrintStream;
 import java.io.Serializable;
+import java.util.Map.Entry;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
@@ -179,8 +180,8 @@ public class PoissonScore extends MessageScorer {
         out.println("Trained=" + m_trained);
         out.println("Total interval count=" + m_totalIntervalCount);
         out.println("min lambda=" + m_minLambda);
-        for (String key : m_msgData.keySet()) {
-            out.println(key + " : " + m_msgData.get(key));
+        for (Entry<String, MsgData> msg : m_msgData.entrySet()) {
+            out.println(msg.getKey() + " : " + msg.getValue());
         }
     }
 

--- a/ade-core/src/main/java/org/openmainframe/ade/scoringApi/StatisticsChart.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/scoringApi/StatisticsChart.java
@@ -235,13 +235,13 @@ public class StatisticsChart {
     public String toString() {
         StringBuilder bldres = new StringBuilder("");
         if (m_doubleStats != null) {
-            for (String key : m_doubleStats.keySet()) {
-                bldres.append(String.format("%-15s: %10.6f\n", key, m_doubleStats.get(key)));
+            for (Entry<String, Double> dStat : m_doubleStats.entrySet()) {
+                bldres.append(String.format("%-15s: %10.6f\n", dStat.getKey(), dStat.getValue()));
             }
         }
         if (m_stringStats != null) {
-            for (String key : m_stringStats.keySet()) {
-                bldres.append(String.format("%-15s: %s\n", key, m_stringStats.get(key)));
+            for (Entry<String, String> sStat : m_stringStats.entrySet()) {
+                bldres.append(String.format("%-15s: %s\n", sStat.getKey(), sStat.getValue()));
             }
         }
         return bldres.toString();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2864 - "entrySet()" should be iterated when both the key and value are needed.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2864

Please let me know if you have any questions.

Faisal Hameed