### PR TITLE
General code quality fix-1

### DIFF
--- a/ade-core/src/main/java/org/openmainframe/ade/main/Train.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/main/Train.java
@@ -301,7 +301,7 @@ abstract class Train extends ControlProgram {
                     break;
                 }
             }
-            if (containsAnalysisGroup == false){
+            if (!containsAnalysisGroup){
                 throw new AdeUsageException("Unknown analysis group: " + analysisGroup + ".\nAvailable analysis groups: " + groupIdToNameMap.values().toString());
             }
         }

--- a/ade-core/src/main/java/org/openmainframe/ade/scores/AbstractClusteringScorer.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/scores/AbstractClusteringScorer.java
@@ -274,7 +274,7 @@ public abstract class AbstractClusteringScorer extends MessageScorer implements 
      * Check complex property relationship (relationships between property keys).
      */
     protected final void processProperties() throws AdeException {
-        if (m_config.m_initialPartitionFromFile != null && m_config.m_initialPartitionOccurrence == true) {
+        if (m_config.m_initialPartitionFromFile != null && m_config.m_initialPartitionOccurrence) {
             throw new AdeUsageException("Two kinds of initial partition were defined: " + m_config.toString());
         }
     }

--- a/ade-core/src/main/java/org/openmainframe/ade/scores/PercentileScorer.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/scores/PercentileScorer.java
@@ -213,11 +213,7 @@ public class PercentileScorer implements IScorer<Double, Double> {
 
     @Override
     public boolean needsAnotherIteration() throws AdeException {
-        if (m_observations == null) {
-            return false;
-        } else {
-            return true;
-        }
+        return m_observations != null;
     }
 
     @Override

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/os/parser/LinuxMessageTextPreprocessor.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/os/parser/LinuxMessageTextPreprocessor.java
@@ -201,11 +201,7 @@ public class LinuxMessageTextPreprocessor implements IMessageTextPreprprocessor 
      */
     @Override
     public final boolean isNonPairedMagicWord(String missing) {
-        if (missing == null || missing.equalsIgnoreCase("root")) {
-            return true;
-        } else {
-            return false;
-        }
+        return (missing == null || missing.equalsIgnoreCase("root"));
     }
     /**
      * Returns true unconditionally. The message text will be considered all one token.

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/output/XMLMetaDataRetriever.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/output/XMLMetaDataRetriever.java
@@ -160,11 +160,7 @@ public class XMLMetaDataRetriever {
          * Note: This code could break, if a model newer than the current code is read by the current code.  This 
          * is because the current code doesn't know if the newer model is still compatible.  
          */
-        if (MODEL_VERSION_SUPPORTED.compareTo(version) <= 0) {
-            return true;
-        } else {
-            return false;
-        }
+        return MODEL_VERSION_SUPPORTED.compareTo(version) <= 0;
     }
 
     /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S1126 - Return of boolean expressions should not be wrapped into an "if-then-else" statement. 
squid:S1125 - Literal boolean values should not be used in condition expressions. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1126
https://dev.eclipse.org/sonar/rules/show/squid:S1125

Please let me know if you have any questions.

Faisal Hameed