### PR TITLE
General code quality fix-3

### DIFF
--- a/ade-core/src/main/java/org/openmainframe/ade/scores/PoissonScore.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/scores/PoissonScore.java
@@ -268,7 +268,7 @@ public class PoissonScore extends MessageScorer {
         m_totalIntervalCount = 1;
     }
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         calcThreshold(0.99, 1.2569444444444444);
 
     }

--- a/ade-core/src/main/java/org/openmainframe/ade/scores/RarityScore.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/scores/RarityScore.java
@@ -56,7 +56,7 @@ public class RarityScore extends MessageScorer {
         }
 
         private static final long serialVersionUID = 1L;
-        int m_counts[];
+        int[] m_counts;
         int m_count = 0;
         double[] m_probs;
         public double m_bernoulliProb;

--- a/ade-core/src/main/java/org/openmainframe/ade/testUtils/StringTestComparator.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/testUtils/StringTestComparator.java
@@ -138,7 +138,7 @@ public class StringTestComparator {
         }
     }
 
-    static public void main(String args[]) throws Exception {
+    static public void main(String[] args) throws Exception {
         String v1 = "hello\nworld\nfoo";
         String v2 = "hello\nworld\nfoo ";
         new StringTestComparator("obj1", v1, "obj2", v2);

--- a/ade-core/src/test/java/org/openmainframe/ade/impl/AdeTest.java
+++ b/ade-core/src/test/java/org/openmainframe/ade/impl/AdeTest.java
@@ -67,7 +67,7 @@ public abstract class AdeTest extends TestCase {
     }
 
     @Override
-    protected void tearDown() throws Exception {
+    public void tearDown() throws Exception {
         super.tearDown();
     }
 
@@ -77,7 +77,7 @@ public abstract class AdeTest extends TestCase {
      * @see junit.framework.TestCase#setUp()
      */
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
         if (!Ade.isCreated()) {
             Ade ade = mock(Ade.class, RETURNS_DEEP_STUBS);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S2391 -  JUnit framework methods should be declared properly.
squid:S1197 - Array designators "[]" should be on the type, not the variable.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2391
https://dev.eclipse.org/sonar/rules/show/squid:S1197

Please let me know if you have any questions.

Faisal Hameed