### PR TITLE
Code quality fix - Classes and methods that rely on the default system encoding should not be used.

### DIFF
--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/output/ExtAnalyzedIntervaFast18lXmlStorer.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/output/ExtAnalyzedIntervaFast18lXmlStorer.java
@@ -21,6 +21,7 @@ package org.openmainframe.ade.ext.output;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.PrintStream;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
@@ -108,8 +109,8 @@ public class ExtAnalyzedIntervaFast18lXmlStorer extends AnalyzedIntervalOutputer
             File parentdir = m_outFile.getParentFile();
             parentdir.mkdirs();
 
-            m_outStream = new PrintStream(m_outFile);
-        } catch (FileNotFoundException e) {
+            m_outStream = new PrintStream(m_outFile, "UTF-8");
+        } catch (IOException e) {
             e.printStackTrace();
         }
     }

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/output/ExtAnalyzedIntervalV2FullXmlStorer.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/output/ExtAnalyzedIntervalV2FullXmlStorer.java
@@ -22,8 +22,8 @@ package org.openmainframe.ade.ext.output;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Writer;
 import java.util.zip.GZIPOutputStream;
@@ -139,7 +139,7 @@ public class ExtAnalyzedIntervalV2FullXmlStorer extends ExtendedAnalyzedInterval
 
                 xmlStreamWriter = new PrintWriter(zos);
             } else {
-                xmlStreamWriter = new FileWriter(outFile);
+                xmlStreamWriter = new OutputStreamWriter(new FileOutputStream(outFile), "UTF-8");
             }
             xmlStreamWriter.write("<?xml version='1.0' encoding='UTF-8' ?> \n");
             xmlStreamWriter.write("<?xml-stylesheet href='" + XSL_FILENAME + "' type=\"text/xsl\" ?> \n");

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/output/ExtJaxbAnalyzedIntervalV2XmlStorer.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/output/ExtJaxbAnalyzedIntervalV2XmlStorer.java
@@ -20,8 +20,9 @@
 package org.openmainframe.ade.ext.output;
 
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.text.DecimalFormat;
@@ -336,11 +337,11 @@ public class ExtJaxbAnalyzedIntervalV2XmlStorer extends ExtendedAnalyzedInterval
         if (m_verbose) {
             System.out.println("saving xml in " + outFile.getAbsolutePath());
         }
-        FileWriter xmlStreamWriter;
+        OutputStreamWriter xmlStreamWriter;
         try {
             File parentdir = outFile.getParentFile();
             parentdir.mkdirs();
-            xmlStreamWriter = new FileWriter(tempOutputFile);
+            xmlStreamWriter = new OutputStreamWriter(new FileOutputStream(tempOutputFile), "UTF-8");
             xmlStreamWriter.write("<?xml version='1.0' encoding='UTF-8' ?> \n");
             xmlStreamWriter.write("<?xml-stylesheet href='" + XSL_FILENAME + "' type='text/xsl' ?> \n");
 

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/utils/NativeCommandOutputParser.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/utils/NativeCommandOutputParser.java
@@ -55,7 +55,7 @@ public class NativeCommandOutputParser extends Thread {
      */
     public final void run() {
         try {
-            final BufferedReader br = new BufferedReader(new InputStreamReader(is));
+            final BufferedReader br = new BufferedReader(new InputStreamReader(is, "UTF-8"));
 
             String line = null;
             while ((line = br.readLine()) != null) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1943 - Classes and methods that rely on the default system encoding should not be used. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1943
 
Please let me know if you have any questions.

Faisal Hameed