### PR TITLE
[squid:UselessParenthesesCheck] Useless parentheses around expressions should be removed

### DIFF
--- a/ade-core/src/main/java/org/openmainframe/ade/impl/data/TextClusteringModel.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/impl/data/TextClusteringModel.java
@@ -359,7 +359,7 @@ public class TextClusteringModel {
             int i;
             String missing = null;
             for (i = 0; i < shorter.size(); ++i) {
-                if (!(shorter.get(i).equals(longer.get(i)))) {
+                if (!shorter.get(i).equals(longer.get(i))) {
                     missing = longer.get(i);
                     break;
                 }

--- a/ade-core/src/main/java/org/openmainframe/ade/impl/dbUtils/MyJDBCConnection.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/impl/dbUtils/MyJDBCConnection.java
@@ -173,7 +173,7 @@ public final class MyJDBCConnection {
          * if it needs to be renewed (by closing their current instance
          * and constructing another).
          */
-        renewConnectionTime = (new Date()).getTime();
+        renewConnectionTime = new Date().getTime();
     }
 
     /**

--- a/ade-core/src/main/java/org/openmainframe/ade/impl/flow/modules/IntervalShiftAccumulator.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/impl/flow/modules/IntervalShiftAccumulator.java
@@ -96,7 +96,7 @@ public class IntervalShiftAccumulator extends HubFrameableFramingBlock<IInterval
     private void fixFramingFlowType(IInterval top) throws AdeException {
         final FramingFlowType fft = top.getIntervalFramingFlowType();
 
-        if (!(m_splitFlow.equals(fft))) {
+        if (!m_splitFlow.equals(fft)) {
             throw new AdeFlowException("flow types missmatch");
         }
         top.setIntervalFramingFlowType(getFramingFlowType());

--- a/ade-core/src/main/java/org/openmainframe/ade/impl/summary/LevenshteinTextSummary.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/impl/summary/LevenshteinTextSummary.java
@@ -178,7 +178,7 @@ public final class LevenshteinTextSummary {
             }
 
             /* adding the directory */
-            addWord(isFirstToken && (!isFirstWord), dirMatcher.group(), strWithDelim);
+            addWord(isFirstToken && !isFirstWord, dirMatcher.group(), strWithDelim);
             isFirstWord = false;
 
             /* adding the suffix after the delimiter */
@@ -218,13 +218,13 @@ public final class LevenshteinTextSummary {
             /* handle the prefix before the delimiter */
             final String currStr = currWord.substring(lastStartIndex, delimtMatcher.end() - 1);
             if (currStr.length() > 0) {
-                addWord(tempIsFirstToken && (!tempIsFirstWord), currStr, strWithDelim);
+                addWord(tempIsFirstToken && !tempIsFirstWord, currStr, strWithDelim);
                 tempIsFirstWord = false;
                 tempIsFirstToken = false;
             }
 
             /* adding the delimiter */
-            addWord(tempIsFirstToken && (!tempIsFirstWord), delimtMatcher.group(), strWithDelim);
+            addWord(tempIsFirstToken && !tempIsFirstWord, delimtMatcher.group(), strWithDelim);
 
             /* adding the suffix after the delimiter */
             suffix = currWord.substring(delimtMatcher.end());
@@ -234,11 +234,11 @@ public final class LevenshteinTextSummary {
         if (isFindMatch) {
             // adding the last subString after the last delimiter
             if (suffix.length() > 0) {
-                addWord(tempIsFirstToken && (!tempIsFirstWord), suffix, strWithDelim);
+                addWord(tempIsFirstToken && !tempIsFirstWord, suffix, strWithDelim);
             }
         } else {
             // in case no delimiter was found
-            addWord(tempIsFirstToken && (!tempIsFirstWord), currWord, strWithDelim);
+            addWord(tempIsFirstToken && !tempIsFirstWord, currWord, strWithDelim);
             tempIsFirstWord = false;
         }
     }
@@ -590,12 +590,12 @@ public final class LevenshteinTextSummary {
                 final String currStr = currWord.substring(lastStartIndex,
                         delimtMatcher.end() - 1);
                 if (currStr.length() > 0) {
-                    addWord(isFirstToken && (!isFirstWord), currStr, strWithDelim);
+                    addWord(isFirstToken && !isFirstWord, currStr, strWithDelim);
                     isFirstWord = false;
                     isFirstToken = false;
                 }
                 // adding the delimiter
-                addWord(isFirstToken && (!isFirstWord), delimtMatcher.group(),
+                addWord(isFirstToken && !isFirstWord, delimtMatcher.group(),
                         strWithDelim);
                 // adding the suffix after the delimiter
                 suffix = currWord.substring(delimtMatcher.end());
@@ -605,11 +605,11 @@ public final class LevenshteinTextSummary {
             if (isFindMatch) {
                 // adding the last subString after the last delimiter
                 if (suffix.length() > 0) {
-                    addWord(isFirstToken && (!isFirstWord), suffix, strWithDelim);
+                    addWord(isFirstToken && !isFirstWord, suffix, strWithDelim);
                 }
             } else {
                 // in case no delimiter was found
-                addWord(isFirstToken && (!isFirstWord), currWord, strWithDelim);
+                addWord(isFirstToken && !isFirstWord, currWord, strWithDelim);
                 isFirstWord = false;
             }
             isFirstWord = false;

--- a/ade-core/src/main/java/org/openmainframe/ade/output/AnalyzedIntervalDbStorer.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/output/AnalyzedIntervalDbStorer.java
@@ -127,7 +127,7 @@ public class AnalyzedIntervalDbStorer extends AnalyzedIntervalOutputer {
 
     private void setCachedPeriod(PeriodImpl period, IBasicInterval ai) throws AdeException {
         //replace period
-        if (!(period.equals(m_cachedPeriod))) {
+        if (!period.equals(m_cachedPeriod)) {
             m_cachedPeriod = period;
 
             readAnalyzedIntervals();

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/data/GroupsQueryImpl.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/data/GroupsQueryImpl.java
@@ -191,7 +191,7 @@ public final class GroupsQueryImpl {
             short evaluationOrder = resultSet.getShort("EVALUATION_ORDER");
             int rid = resultSet.getInt("RULE_INTERNAL_ID");
             String ruleName = getRuleName(rid);
-            return (new Group(uid,name,groupType,dataType,evaluationOrder,ruleName));            
+            return new Group(uid,name,groupType,dataType,evaluationOrder,ruleName);            
         }
         /**
          * Retrieves the rule name by selecting the row with the given unique rule id. 
@@ -850,8 +850,8 @@ public final class GroupsQueryImpl {
          */
         private boolean unassignedIsInGroups(List<Group> groups, int groupId){
             for (Group group : groups){
-                if (group != null && (group.getUid() == groupId) && 
-                        (group.getName().equalsIgnoreCase(UNASSIGNED_GROUP))){
+                if (group != null && (group.getUid() == groupId) &&
+                        group.getName().equalsIgnoreCase(UNASSIGNED_GROUP)){
                     return true;
                 }
             }

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/data/RulesQueryImpl.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/data/RulesQueryImpl.java
@@ -101,7 +101,7 @@ public final class RulesQueryImpl {
             String description = ruleListResultSet.getString("DESCRIPTION");
             String rule = ruleListResultSet.getString("RULE");
             
-            return (new Rule(uid, name, rule, description));
+            return new Rule(uid, name, rule, description);
         }    
     }
 

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/os/parser/LinuxSyslogMessageReader.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/os/parser/LinuxSyslogMessageReader.java
@@ -415,7 +415,7 @@ public class LinuxSyslogMessageReader extends AdeMessageReader {
      */
     private DateTime handleDateTime(LinuxSyslogLineParser lineParser){
         final DateTime dateTime = lineParser.getLastDeterminedDateTime();
-        if (dateTime != null && !(m_adeExtProperties.isGmtOffsetDefined())) {
+        if (dateTime != null && !m_adeExtProperties.isGmtOffsetDefined()) {
             updateGmtOffset(dateTime);
         }
         return dateTime;

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/stats/PeriodicStats.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/stats/PeriodicStats.java
@@ -194,7 +194,7 @@ public abstract class PeriodicStats {
      * @return String timestamp representation
      */
     protected final String currentTimeStamp() {
-        return dateFormatter.format((new Date()).getTime());
+        return dateFormatter.format(new Date().getTime());
     }
 
     /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessParenthesesCheck - “ Useless parentheses around expressions should be removed to prevent any misunderstanding ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
Ayman Abdelghany.