### PR TITLE
[squid:S1319] Use Java collection interfaces rather than specific implementation

### DIFF
--- a/ade-core/src/main/java/org/openmainframe/ade/core/ListSortedByKey.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/core/ListSortedByKey.java
@@ -22,6 +22,7 @@ package org.openmainframe.ade.core;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.List;
 
 /** An object for storing a list of V objects, sorted by key K objects
  * And optionally secondary sort by the V objects.
@@ -48,7 +49,7 @@ public class ListSortedByKey<K, V> {
     /**
      * Internal list of items (=key value pair).
      */
-    private ArrayList<Item> mItems = new ArrayList<Item>();
+    private List<Item> mItems = new ArrayList<Item>();
     /**
      * Is list sorted (sorting is performed lazily).
      */

--- a/ade-core/src/main/java/org/openmainframe/ade/core/clustering/IClustExp.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/core/clustering/IClustExp.java
@@ -54,7 +54,7 @@ public class IClustExp implements IClusteringAlgorithm {
     private int mIdleTrials;
     private int mVerbosity = 0;
     private PrintStream mVerbosityOut = null;
-    private ArrayList<Double> mScoreArchive = null;
+    private List<Double> mScoreArchive = null;
     private int[] mCandidateClusters = null;
     private int mCandidateClustersNum = 0;
     private boolean mConverged;
@@ -73,7 +73,7 @@ public class IClustExp implements IClusteringAlgorithm {
     private int[] mElementsPermutation = null;
     private int mElementsPermutationIndex = 0;
 
-    private ArrayList<IClustRunSummary> mRunsSummary = null;
+    private List<IClustRunSummary> mRunsSummary = null;
 
     public class IClustRunSummary extends IClusteringAlgorithm.RunSummary {
         private static final long serialVersionUID = 1L;
@@ -114,7 +114,7 @@ public class IClustExp implements IClusteringAlgorithm {
             public Map<Integer, Double> mCandidateCalculatedExtraTermSum;
             public Map<Integer, Integer> mCandidateCalculatedExtraTermSumN;
 
-            public Cluster(int index, ArrayList<Integer> members) {
+            public Cluster(int index, List<Integer> members) {
 
                 mIndex = index;
                 for (int i : members) {
@@ -339,7 +339,7 @@ public class IClustExp implements IClusteringAlgorithm {
         private ArrayList<Cluster> mClusters = new ArrayList<Cluster>();
 
         public Partition() {
-            ArrayList<Integer> indices = new ArrayList<Integer>();
+            List<Integer> indices = new ArrayList<Integer>();
             for (int i = 0; i < mNumElements; ++i) {
                 indices.add(i);
             }
@@ -360,8 +360,8 @@ public class IClustExp implements IClusteringAlgorithm {
         }
 
         public Partition(int[] initialPartition) {
-            HashMap<Integer, Integer> clusterIdx = new HashMap<Integer, Integer>();
-            HashMap<Integer, ArrayList<Integer>> clusters = new HashMap<Integer, ArrayList<Integer>>();
+            Map<Integer, Integer> clusterIdx = new HashMap<Integer, Integer>();
+            Map<Integer, ArrayList<Integer>> clusters = new HashMap<Integer, ArrayList<Integer>>();
             mClusterIndices = initialPartition.clone();
             int k = 0;
             for (int i = 0; i < initialPartition.length; ++i) {

--- a/ade-core/src/main/java/org/openmainframe/ade/core/clustering/KMeans.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/core/clustering/KMeans.java
@@ -69,7 +69,7 @@ public class KMeans implements IClusteringAlgorithm, Serializable {
     protected IBinaryDoubleVectorFunc mDistanceFunc = new DoubleVectorOps.BinaryDoubleVectorL2Squared();
 
     // Summary list - for performance evaluation.
-    protected ArrayList<RunSummary> mRunSummary = null;
+    protected List<RunSummary> mRunSummary = null;
 
     public KMeans() {
         mGlobalRandom = new Random();

--- a/ade-core/src/main/java/org/openmainframe/ade/core/statistics/TimingStatistics.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/core/statistics/TimingStatistics.java
@@ -31,6 +31,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.math3.util.Pair;
@@ -122,7 +123,7 @@ public class TimingStatistics {
     }
 
     private HashMap<String, Measure> mMeasures = new HashMap<String, Measure>();
-    private HashMap<Pair<Long, String>, Long> mThreadMeasures = new HashMap<Pair<Long, String>, Long>();
+    private Map<Pair<Long, String>, Long> mThreadMeasures = new HashMap<Pair<Long, String>, Long>();
     private List<Measure> mOrderedMeasures = new ArrayList<Measure>();
     private Set<String> mDuplicateStarts = new HashSet<String>();
     private Set<String> mEndsWithoutStarts = new HashSet<String>();
@@ -138,7 +139,7 @@ public class TimingStatistics {
 
     private static ThreadLocal<String> mFinalPrefix = new ThreadLocal<String>();
 
-    private static HashMap<String, Measure> getMeasures() {
+    private static Map<String, Measure> getMeasures() {
         return mInstance.mMeasures;
     }
 

--- a/ade-core/src/main/java/org/openmainframe/ade/dbUtils/SimpleQueries.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/dbUtils/SimpleQueries.java
@@ -25,6 +25,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 import org.openmainframe.ade.Ade;
 import org.openmainframe.ade.exceptions.AdeException;
@@ -147,7 +148,7 @@ public class SimpleQueries {
      * @throws AdeException
      */
 
-    public final ArrayList<Integer> executeIntListQuery(String sql) throws AdeException {
+    public final List<Integer> executeIntListQuery(String sql) throws AdeException {
         return SpecialSqlQueries.executeIntListQuery(sql, m_connection);
     }
 

--- a/ade-core/src/main/java/org/openmainframe/ade/impl/dataStore/DataStorePeriodsImpl.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/impl/dataStore/DataStorePeriodsImpl.java
@@ -232,7 +232,7 @@ public class DataStorePeriodsImpl implements IDataStorePeriods {
 
     private static class PeriodLoader extends QueryPreparedStatementExecuter {
 
-        private ArrayList<PeriodImpl> m_result = new ArrayList<PeriodImpl>();
+        private List<PeriodImpl> m_result = new ArrayList<PeriodImpl>();
         private ISource m_source;
         private Date m_end;
         private Date m_start;

--- a/ade-core/src/main/java/org/openmainframe/ade/impl/dataStore/ModelMetaDataLoader.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/impl/dataStore/ModelMetaDataLoader.java
@@ -51,7 +51,7 @@ class ModelMetaDataLoader {
         return res;
     }
 
-    ArrayList<IModelMetaData> loadAll() throws AdeException {
+    List<IModelMetaData> loadAll() throws AdeException {
         final ArrayList<IModelMetaData> res = new ArrayList<IModelMetaData>();
         res.addAll(loadAllImpl());
         return res;

--- a/ade-core/src/main/java/org/openmainframe/ade/impl/dbUtils/CodeTableSqlStatements.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/impl/dbUtils/CodeTableSqlStatements.java
@@ -23,6 +23,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -114,7 +115,7 @@ public class CodeTableSqlStatements {
     private class WordReader extends QueryPreparedStatementExecuter {
 
         private int m_id;
-        private ArrayList<String> m_words = new ArrayList<String>();
+        private List<String> m_words = new ArrayList<String>();
 
         WordReader(int id) {
             super(String.format("select %s from %s where %s=?",

--- a/ade-core/src/main/java/org/openmainframe/ade/impl/stats/IntervalStatsCollector.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/impl/stats/IntervalStatsCollector.java
@@ -182,7 +182,7 @@ class IntervalStatsCollector extends HubStreamBlock<IInterval, IInterval> {
 
     private static class NumNewMsgIdsInIntervalStat extends IntervalStatManager {
 
-        static HashSet<String> oldMessageIds = new HashSet<String>();
+        static Set<String> oldMessageIds = new HashSet<String>();
 
         protected NumNewMsgIdsInIntervalStat(File dir) throws AdeInternalException {
             super(new File(dir, "numNewMsgIdsInInterval.txt"), "The number of new message IDs in an interval (per interval)");

--- a/ade-core/src/main/java/org/openmainframe/ade/impl/summary/CriticalWordsScorer.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/impl/summary/CriticalWordsScorer.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
+import java.util.Set;
 
 import org.openmainframe.ade.exceptions.AdeInternalException;
 
@@ -36,7 +37,7 @@ import org.openmainframe.ade.exceptions.AdeInternalException;
 public class CriticalWordsScorer {
 
     public static final int INIT_SIZE = 30;
-    private HashSet<String> m_criticalWordsSet = null;
+    private Set<String> m_criticalWordsSet = null;
     private File m_criticalWordsFile = null;
 
     public CriticalWordsScorer(String criticalWordsFile) throws AdeInternalException {

--- a/ade-core/src/main/java/org/openmainframe/ade/impl/summary/MessageSummaryBuilder.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/impl/summary/MessageSummaryBuilder.java
@@ -19,6 +19,7 @@
 */
 package org.openmainframe.ade.impl.summary;
 
+import java.util.Set;
 import java.util.TreeSet;
 
 import org.openmainframe.ade.AdeInternal;
@@ -44,7 +45,7 @@ public class MessageSummaryBuilder implements IStreamTarget<IMessageInstance> {
 
     private MessageSummaryImpl m_messageSummary;
     private SummarizationProperties m_sumProps;
-    private TreeSet<Short> m_timeLine;
+    private Set<Short> m_timeLine;
     private boolean m_messageSummaryReady = false;
     private CriticalWordsScorer m_textScore = null;
     private long m_intervalStartTime;

--- a/ade-core/src/main/java/org/openmainframe/ade/impl/training/ClusteringPartition.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/impl/training/ClusteringPartition.java
@@ -56,9 +56,9 @@ public class ClusteringPartition implements Serializable {
     /**
      * A map for storing an initial clustering partition.
      */
-    private HashMap<String, ArrayList<Integer>> m_initialClusters = null;
+    private Map<String, ArrayList<Integer>> m_initialClusters = null;
 
-    private HashMap<String, Collection<Integer>> m_finalClusters = null;
+    private Map<String, Collection<Integer>> m_finalClusters = null;
     private transient Map<Integer, String> m_finalClusterNames = null;
 
     private int[] m_initialPartition = null;
@@ -277,7 +277,7 @@ public class ClusteringPartition implements Serializable {
 
         for (Map.Entry<String, ArrayList<Integer>> entry : m_initialClusters.entrySet()) {
             final String n = entry.getKey();
-            final ArrayList<Integer> members = entry.getValue();
+            final List<Integer> members = entry.getValue();
             int intersectionCount = 0;
             int unionCount = members.size();
 

--- a/ade-core/src/main/java/org/openmainframe/ade/impl/training/MsgMutualInformation.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/impl/training/MsgMutualInformation.java
@@ -363,7 +363,7 @@ public class MsgMutualInformation implements IFrameableTarget<IInterval, TimeSep
      * @throws AdeException
      */
     public void printMemberReport(PrintWriter out, int member,
-            TreeSet<Integer> cluster) throws AdeException {
+            Set<Integer> cluster) throws AdeException {
         out.printf("%-15s:\n", memberStr(member));
 
         final ListSortedByKey<Double, String> list = new ListSortedByKey<Double, String>();

--- a/ade-core/src/main/java/org/openmainframe/ade/output/AnalyzedIntervalXmlStorer.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/output/AnalyzedIntervalXmlStorer.java
@@ -250,7 +250,7 @@ public class AnalyzedIntervalXmlStorer extends AnalyzedIntervalOutputer {
     }
 
     public static Collection<IAnalyzedMessageSummary> getSortedMessages(IAnalyzedInterval interval) {
-        final ArrayList<IAnalyzedMessageSummary> sortedMessages = new ArrayList<IAnalyzedMessageSummary>();
+        final List<IAnalyzedMessageSummary> sortedMessages = new ArrayList<IAnalyzedMessageSummary>();
         sortedMessages.addAll(interval.getAnalyzedMessages());
         Collections.sort(sortedMessages, new AnomalyScoreComparator());
         return sortedMessages;

--- a/ade-core/src/main/java/org/openmainframe/ade/scores/AbstractClusteringScorer.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/scores/AbstractClusteringScorer.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -306,7 +307,7 @@ public abstract class AbstractClusteringScorer extends MessageScorer implements 
         private int m_msgAppearThreshold;
         private boolean m_converged;
 
-        private ArrayList<String> m_runsSummary;
+        private List<String> m_runsSummary;
 
         /**
          * Constructor for Model - use reset() instead.
@@ -471,7 +472,7 @@ public abstract class AbstractClusteringScorer extends MessageScorer implements 
 
         @Override
         public final void incomingObject(IInterval interval) throws AdeException {
-            final ArrayList<IMessageSummary> msgSummaries = 
+            final List<IMessageSummary> msgSummaries = 
                     new ArrayList<IMessageSummary>(interval.getMessageSummaries());
             for (IMessageSummary messageSummary : msgSummaries) {
                 mCounter.add(messageSummary.getMessageInternalId());
@@ -638,7 +639,7 @@ public abstract class AbstractClusteringScorer extends MessageScorer implements 
             clusterData = calcClusterData(clusterPartition);
             //generate a mapping from msgIDs to their cluster
             int goodClusters = 0;
-            final HashMap<Integer, Integer> msgId2Cluster = new HashMap<Integer, Integer>();
+            final Map<Integer, Integer> msgId2Cluster = new HashMap<Integer, Integer>();
             final Map<Integer, String> clusterNames = new HashMap<Integer, String>();
 
             int clusteredMsgCount = 0;
@@ -676,7 +677,7 @@ public abstract class AbstractClusteringScorer extends MessageScorer implements 
         }
 
         protected void outputClusterMembership(int[] matIndexToMsgInternalId,
-                ArrayList<ClusterData> clusterData)
+                List<ClusterData> clusterData)
                 throws AdeUsageException, AdeException {
             final PrintWriter out = FileUtils.openPrintWriterToFile(new File(m_scorerEnvironment.m_traceOutputPath, 
                     "clustering.clusterMembers.txt"), true);
@@ -690,7 +691,7 @@ public abstract class AbstractClusteringScorer extends MessageScorer implements 
          * @param clusterPartition raw clustering partition reported
          * @param survivingClusters  subset of the clusters actually used
          */
-        private void printReport(File file, ArrayList<ClusterData> clusterData) throws AdeException {
+        private void printReport(File file, List<ClusterData> clusterData) throws AdeException {
             final PrintWriter out = FileUtils.openPrintWriterToFile(file, true);
 
             if (!Double.isNaN(m_model.m_meanInfo)){
@@ -765,7 +766,7 @@ public abstract class AbstractClusteringScorer extends MessageScorer implements 
             return clusterData;
         }
 
-        private double calcClusterMeanInfo(TreeSet<Integer> members) throws AdeInternalException {
+        private double calcClusterMeanInfo(Set<Integer> members) throws AdeInternalException {
             if (members.size() == 1){
                 return 0;
             }

--- a/ade-core/src/main/java/org/openmainframe/ade/scores/LastSeenLoggingScorerContinuous.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/scores/LastSeenLoggingScorerContinuous.java
@@ -293,7 +293,7 @@ public class LastSeenLoggingScorerContinuous extends FixedMessageScorer {
      * @throws AdeInternalException
      */
     public void processPrevTimeLine(String messageID, IAnalyzedInterval contextElement, StatisticsChart sc,
-            TreeSet<Long> timeLineSet) throws AdeInternalException{ 
+            Set<Long> timeLineSet) throws AdeInternalException{ 
         final TreeSet<Long> prevTimeLine = m_prevIntervalTimelineMap.get(messageID);
         if (prevTimeLine == null) {
             m_mainStat = MainStatVal.NEW;
@@ -317,7 +317,7 @@ public class LastSeenLoggingScorerContinuous extends FixedMessageScorer {
      * @param contextElement AnalyzedInterval object that contains summary results of interval.
      * @param millisPerTick Long value with number of milliseconds per tick. 
      */
-    public void processCurrentTimeLine(short[] timeLine,TreeSet<Long> timeLineSet,IAnalyzedInterval contextElement){
+    public void processCurrentTimeLine(short[] timeLine, Set<Long> timeLineSet, IAnalyzedInterval contextElement){
         final boolean hasTimeline = !ArrayUtils.isEmpty(timeLine);
         final long millisPerTick = contextElement.getInterval().getIntervalSize() / 
                 SummarizationProperties.TIMELINE_RESOLUTION;

--- a/ade-core/src/main/java/org/openmainframe/ade/scores/PercentileScorer.java
+++ b/ade-core/src/main/java/org/openmainframe/ade/scores/PercentileScorer.java
@@ -21,6 +21,7 @@ package org.openmainframe.ade.scores;
 
 import java.io.PrintStream;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NavigableMap;
@@ -62,7 +63,7 @@ public class PercentileScorer implements IScorer<Double, Double> {
     public static final int NUM_PERCENTILE_BINS = 100;
 
     private class GetVecMemberFromFullIndex {
-        ArrayList<Double> m_vec;
+        List<Double> m_vec;
         int m_totalNumIntervals;
         int m_numIntervalsWithZeroOccurrences;
 

--- a/ade-core/src/test/java/org/openmainframe/ade/impl/flow/TestMultiLogTracker.java
+++ b/ade-core/src/test/java/org/openmainframe/ade/impl/flow/TestMultiLogTracker.java
@@ -23,6 +23,7 @@ package org.openmainframe.ade.impl.flow;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
+import java.util.List;
 import java.util.PriorityQueue;
 import java.util.Random;
 
@@ -237,7 +238,7 @@ public class TestMultiLogTracker extends TestCase {
 
         private int m_curLen;
 
-        ArrayList<Message> m_messages = new ArrayList<Message>();
+        List<Message> m_messages = new ArrayList<Message>();
         Message m_lastMessage;
 
         public DummyProcessor(String name) {

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/data/GroupsQueryImpl.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/data/GroupsQueryImpl.java
@@ -394,7 +394,7 @@ public final class GroupsQueryImpl {
          * @return patternList a list of patterns for each group rule.
          * @throws SQLException
          */
-        private ArrayList<Pattern> getPatternList(List<Group> groups) throws SQLException{
+        private List<Pattern> getPatternList(List<Group> groups) throws SQLException{
             final ArrayList<Pattern> patternList = new ArrayList<Pattern>();
             PreparedStatement ruleStatement = null;
             ResultSet ruleResult = null;

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/data/ManagedSystemInfo.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/data/ManagedSystemInfo.java
@@ -374,7 +374,7 @@ public class ManagedSystemInfo {
          * @param ISource - datastore object which is associated with a SOURCES Table row
          * @return ArrayList<String> as described above
          */
-        private ArrayList<String> getSqlForAdd(ISource S) {
+        private List<String> getSqlForAdd(ISource S) {
 
             logger.trace("getSqlForAdd() -->entry");
 
@@ -410,7 +410,7 @@ public class ManagedSystemInfo {
          *                 and also wth a MANAGED_SYSTEMS Table row
          * @return ArrayList<String> as described above
          */
-        private ArrayList<String> getSqlForUpdate(ISource S) {
+        private List<String> getSqlForUpdate(ISource S) {
 
             final List<String> msSets = new ArrayList<String>();
             String SET_STRING, WHERE_STRING, UPDATE_STRING;

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/data/RulesQueryImpl.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/data/RulesQueryImpl.java
@@ -134,7 +134,7 @@ public final class RulesQueryImpl {
                 List<Rule> rulesToDelete = getRulesToDelete(currentRules);
                 List<Rule> rulesToUpdate = getRulesToUpdate(currentRules, rulesToDelete);
                 
-                ArrayList<String> batchList = new ArrayList<String>();
+                List<String> batchList = new ArrayList<String>();
                 deleteRules(batchList, rulesToDelete);
                 addRules(batchList, rulesToAdd);
                 updateRules(batchList, rulesToUpdate);

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/main/DatabaseManager.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/main/DatabaseManager.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.Map;
 import java.util.Properties;
 
 import org.openmainframe.ade.exceptions.AdeException;
@@ -471,7 +472,7 @@ public class DatabaseManager {
      * @return a connection object to Derby DB
      */
     private static Connection getEmbeddedDBConnection(String dirName) throws AdeException {
-        final Properties p = System.getProperties();
+        final Map p = System.getProperties();
         p.put("derby.system.home", dirName);
         Connection con = null;
 

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/main/UpdateGroups.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/main/UpdateGroups.java
@@ -22,6 +22,7 @@ package org.openmainframe.ade.ext.main;
 import java.io.File;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -173,7 +174,7 @@ public class UpdateGroups extends ExtControlProgram{
      * @param parsedRules the rules extracted from the JSON file.
      * @throws AdeException
      */
-    private void updateDB(HashMap<Integer, List<Group>> parsedGroupsByType, List<Rule> parsedRules) throws AdeException {
+    private void updateDB(Map<Integer, List<Group>> parsedGroupsByType, List<Rule> parsedRules) throws AdeException {
         RulesQueryImpl.modifyRules(parsedRules);
         for (GroupType groupType : GroupType.values()){
             int groupTypeVal = groupType.getValue();

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/main/helper/LinuxOptions.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/main/helper/LinuxOptions.java
@@ -20,6 +20,7 @@
 package org.openmainframe.ade.ext.main.helper;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.OptionBuilder;
@@ -46,13 +47,13 @@ public class LinuxOptions extends AdeExtOptions{
     public boolean readOptions(CommandLine line, AdeExtProperties linuxProperties){
         boolean readOptionsSuccessful = true;
         /* All the required parameters for Linux */
-        ArrayList<String> requiredParameterList = new ArrayList<String>();
+        List<String> requiredParameterList = new ArrayList<String>();
         requiredParameterList.add(AdeExtOptions.OPTION_GMT_OFFSET);
 
-        ArrayList<String> optionalParameterList = new ArrayList<String>();
+        List<String> optionalParameterList = new ArrayList<String>();
         optionalParameterList.add(OPTION_YEAR);
 
-        ArrayList<String> allParameterList = new ArrayList<String>();
+        List<String> allParameterList = new ArrayList<String>();
         allParameterList.addAll(optionalParameterList);
         allParameterList.addAll(requiredParameterList);
 

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/os/parser/InputTimeZoneManager.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/os/parser/InputTimeZoneManager.java
@@ -20,6 +20,7 @@
 package org.openmainframe.ade.ext.os.parser;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import org.joda.time.DateTime;
 import org.openmainframe.ade.Ade;
@@ -36,7 +37,7 @@ public final class InputTimeZoneManager {
     /**
      * A map from the source ID to dateTime object.
      */
-    private static HashMap<String, DateTime> s_sourceToTimeZoneMap = new HashMap<String, DateTime>();
+    private static Map<String, DateTime> s_sourceToTimeZoneMap = new HashMap<String, DateTime>();
 
     /**
      * The default GMT Offset from setup.props.

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/os/parser/LinuxSyslogMessageReader.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/os/parser/LinuxSyslogMessageReader.java
@@ -26,6 +26,7 @@ import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 
@@ -189,7 +190,7 @@ public class LinuxSyslogMessageReader extends AdeMessageReader {
     /**
      * Hashmap mapping SysId to Source ID.
      */
-    private HashMap<String, String> sourceToSourceIdMap = new HashMap<String, String>();
+    private Map<String, String> sourceToSourceIdMap = new HashMap<String, String>();
 
     /**
      * The Linux specific properties to be used containing configurations from start of AdeExt main class.

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/os/parser/RuntimeModelDataManager.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/os/parser/RuntimeModelDataManager.java
@@ -31,6 +31,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -329,7 +330,7 @@ public class RuntimeModelDataManager {
         DataInputStream dis = null;
         FileInputStream fis;
         String timeSinceLastRuntimeModelDataWriting = "-1";
-        final ArrayList<Entry<String, Object>> tmpModelData = new ArrayList<Map.Entry<String, Object>>();
+        final List<Entry<String, Object>> tmpModelData = new ArrayList<Map.Entry<String, Object>>();
         try {
             fis = new FileInputStream(file);
             dis = new DataInputStream(fis);

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/stats/MessageRateStats.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/stats/MessageRateStats.java
@@ -21,6 +21,7 @@ package org.openmainframe.ade.ext.stats;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.TimeZone;
 
 import org.openmainframe.ade.Ade;
@@ -48,7 +49,7 @@ public class MessageRateStats {
     /**
      * A map from Source to Analysis Group
      */
-    private static HashMap<String, String> s_sourceToAnalysisGroupMap = new HashMap<String, String>();
+    private static Map<String, String> s_sourceToAnalysisGroupMap = new HashMap<String, String>();
 
     public static void addSourceAndAnalysisGroup(String sourceName, String analysisGroupName) {
         s_sourceToAnalysisGroupMap.put(sourceName, analysisGroupName);
@@ -57,7 +58,7 @@ public class MessageRateStats {
     /**
      * A map containing the message Rate Stats 
      */
-    private static HashMap<String, MessageRateStats> s_sourceToMsgRatesStatsMap = new HashMap<String, MessageRateStats>();
+    private static Map<String, MessageRateStats> s_sourceToMsgRatesStatsMap = new HashMap<String, MessageRateStats>();
 
     public static MessageRateStats getMessageRateStatsForSource(String source) throws AdeException {
         MessageRateStats stats;
@@ -225,7 +226,7 @@ public class MessageRateStats {
     /**
      * A map from Msg ID to the MsgStats object.
      */
-    private HashMap<String, MessageStats> m_msgIdToMsgStatsMap = new HashMap<String, MessageRateStats.MessageStats>();
+    private Map<String, MessageStats> m_msgIdToMsgStatsMap = new HashMap<String, MessageRateStats.MessageStats>();
     private final static int MAX_MESSAGE_STATS_TO_KEEP = 1000;
     private static int s_maxMsgToKeep = 1000;
 

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/stats/MessagesWithParseErrorStats.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/stats/MessagesWithParseErrorStats.java
@@ -22,6 +22,8 @@ package org.openmainframe.ade.ext.stats;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -100,7 +102,7 @@ public class MessagesWithParseErrorStats {
     /**
      * A mapping from MsgRep to Msg Stats
      */
-    private HashMap<String, MessageStats> m_msgRepToMsgStatsMap;
+    private Map<String, MessageStats> m_msgRepToMsgStatsMap;
 
     /**
      * Whether there are new errors
@@ -171,7 +173,7 @@ public class MessagesWithParseErrorStats {
             writeToLog();
 
             /* Perform cleanup */
-            final ArrayList<MessageStats> statsArray = new ArrayList<MessageStats>(m_msgRepToMsgStatsMap.values());
+            final List<MessageStats> statsArray = new ArrayList<MessageStats>(m_msgRepToMsgStatsMap.values());
             Collections.sort(statsArray);
 
             /* Remove the first few Stats from the beginning of the list, until we reach the max */
@@ -257,7 +259,7 @@ public class MessagesWithParseErrorStats {
             } else {
                 /* Only output this if there are new errors */
 
-                final ArrayList<MessageStats> statsArray = new ArrayList<MessageStats>(m_msgRepToMsgStatsMap.values());
+                final List<MessageStats> statsArray = new ArrayList<MessageStats>(m_msgRepToMsgStatsMap.values());
                 Collections.sort(statsArray);
 
                 statslogger.info("Parser Errors as of: " + s_dateTimeFormatter.print(DateTime.now()));

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/stats/MessagesWithUnexpectedSource.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/stats/MessagesWithUnexpectedSource.java
@@ -21,6 +21,7 @@
 package org.openmainframe.ade.ext.stats;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,7 +43,7 @@ public final class MessagesWithUnexpectedSource {
     /**
      * Map from source name to the SourceStatisticsForMessage object
      */
-    private static HashMap<String, SourceStatisticsForMessage> sourceToStatisticsMap = new HashMap<String, MessagesWithUnexpectedSource.SourceStatisticsForMessage>();
+    private static Map<String, SourceStatisticsForMessage> sourceToStatisticsMap = new HashMap<String, MessagesWithUnexpectedSource.SourceStatisticsForMessage>();
 
     /**
      * Add a message that belongs to an unexpected source.

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/utils/ArgumentConstants.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/utils/ArgumentConstants.java
@@ -25,6 +25,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 import java.util.Set;
 
 import org.openmainframe.ade.Ade;
@@ -81,7 +82,7 @@ public class ArgumentConstants {
             reportInvalidSysId("'all' not allowed here. Please specifiy a system id.");
         }
 
-        final ArrayList<ISource> result = new ArrayList<ISource>();
+        final List<ISource> result = new ArrayList<ISource>();
         final ISource res = dataStoreSources.getSource(sysId);
         if (res != null) {
             result.add(res);

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/utils/AtomicTransaction.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/utils/AtomicTransaction.java
@@ -272,7 +272,7 @@ public abstract class AtomicTransaction {
         return I;
     } 
 
-    private <T extends Statement> T addAndReturnStatement(ArrayList<Statement> statementList, T statement) {
+    private <T extends Statement> T addAndReturnStatement(List<Statement> statementList, T statement) {
         statementList.add(statement);
         return statement;
     }

--- a/ade-ext/src/main/java/org/openmainframe/ade/ext/utils/ExtDataStoreUtils.java
+++ b/ade-ext/src/main/java/org/openmainframe/ade/ext/utils/ExtDataStoreUtils.java
@@ -26,6 +26,7 @@ import java.sql.SQLException;
 import java.sql.SQLNonTransientConnectionException;
 import java.sql.Statement;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 import org.openmainframe.ade.Ade;
@@ -581,7 +582,7 @@ public final class ExtDataStoreUtils {
      *           of the input SQL statement(s) did not raise
      *           any exceptions, false to indicate that it did.
      */
-    public static synchronized boolean executeBatch(ArrayList<String> sqlStatement) { 
+    public static synchronized boolean executeBatch(List<String> sqlStatement) { 
 
         boolean batchOk = false;
         logger.trace("executeBatch() -->entry");

--- a/ade-ext/src/test/java/org/openmainframe/ade/ext/os/parser/TestJSONGroupParser.java
+++ b/ade-ext/src/test/java/org/openmainframe/ade/ext/os/parser/TestJSONGroupParser.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Test;
 import org.junit.Before;
@@ -209,7 +210,7 @@ public class TestJSONGroupParser {
         rulesArray.put(rule2);
         rulesArray.put(rule3);
         writeToFileAndParseJSON();
-        HashMap<Integer, List<Group>> parsedGroupsByType = jsonGroupParser.getParsedGroupsByType();
+        Map<Integer, List<Group>> parsedGroupsByType = jsonGroupParser.getParsedGroupsByType();
         List<Rule> parsedRules = jsonGroupParser.getParsedRules();
         for (int i = 0 ; i < parsedRules.size(); i++){
             assertRulesEqual(rules.get(i),parsedRules.get(i));


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1319 - “Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList" ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1319
Please let me know if you have any questions.
Ayman Abdelghany.