### PR TITLE
Bump xercesImpl from 2.11.0 to 2.12.0 in /ade-core

### DIFF
--- a/ade-core/pom.xml
+++ b/ade-core/pom.xml
@@ -128,7 +128,7 @@
     <dependency>
       <groupId>xerces</groupId>
       <artifactId>xercesImpl</artifactId>
-      <version>2.11.0</version>
+      <version>2.12.0</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Bumps xercesImpl from 2.11.0 to 2.12.0.

Signed-off-by: dependabot[bot] <support@github.com>