### PR TITLE
Dynamically adjust the number of Forked VM based on the number of CPU cores

### DIFF
--- a/ade-core/pom.xml
+++ b/ade-core/pom.xml
@@ -24,7 +24,7 @@
         <version>2.18.1</version>
         <configuration>
           <reuseForks>false</reuseForks>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <includes>
             <include>org/openmainframe/ade/impl/utils/*.java</include>
             <include>org/openmainframe/ade/impl/dbUtils/*.java</include>

--- a/ade-ext/pom.xml
+++ b/ade-ext/pom.xml
@@ -23,7 +23,7 @@
         <version>2.19.1</version>
         <configuration>
             <reuseForks>false</reuseForks>
-            <forkCount>1</forkCount>
+            <forkCount>1.5C</forkCount>
         </configuration>
       </plugin>
 	  <plugin>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
